### PR TITLE
Removed 33px offset

### DIFF
--- a/timber-debug-bar.css
+++ b/timber-debug-bar.css
@@ -22,10 +22,6 @@
     font-family: Consolas, mono, serif;
 }
 
-#wpadminbar .ab-top-secondary {
-    top: -33px;
-}
-
 #debug-bar-actions span {
     padding: 3px;
 }


### PR DESCRIPTION
This caused the debug bar to totally vanish in the frontend.
Was there any reason for this rule?