### PR TITLE
Check for Debug_Bar class later.

### DIFF
--- a/debug-bar-timber.php
+++ b/debug-bar-timber.php
@@ -26,7 +26,7 @@ add_action('init', static function() {
 			echo '<div class="'.$class.'"><p>'.$text.'</p></div>';
 		}, 1 );
 	}
-});
+}, 11);
 
 function tdb_enqueue_styles() {
 	wp_enqueue_style( 'dbt', plugins_url( "timber-debug-bar.css", __FILE__ ), [], '20200710' );


### PR DESCRIPTION
When the Debug_Bar class is supplied by Query Monitor, the check for it can run too early. 

Query monitor instantiates the Debug_Bar class on the `init` action at the default priority of 10. 
https://github.com/johnbillion/query-monitor/blob/develop/collectors/debug_bar.php#L109 and https://github.com/johnbillion/query-monitor/blob/develop/collectors/debug_bar.php#L46

Debug bar timber also checks on the same action with the same priority. This means it can sometimes check too early.
Resulting in the incorrect message 
"In order to use the Timber Debug Bar, you need to install and activate the WordPress Debug Bar Plugin"

![Plugins_‹_I_m_a_Scientist__Get_me_out_of_here__—_WordPress](https://user-images.githubusercontent.com/358499/111343908-c9353300-8673-11eb-9e50-e7fa197925d8.png)

This PR changes the priority to 11 to ensure Query Monitor runs first.
